### PR TITLE
修复 dev 模式下不能 watch 文件的问题

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "author": "dewfall",
   "license": "MIT",
   "scripts": {
-    "dev": "vitepress-fc --root=docs",
+    "dev": "vitepress-fc dev --root=docs",
     "test": "jest",
     "build": "rimraf dist/ && rollup -c",
     "docs-deploy": "gh-pages -d docs/dist -t true",


### PR DESCRIPTION
vitepress-for-component@0.12.2 版本里修改了 genTemporary 函数的入参。如果 scripts 里的 dev 命令如果缺少 ‘dev’ 参数，会导致项目启动后不能 watch 文件变化